### PR TITLE
Use ParaView_VERSION instead of PARAVIEW_USE_FILE to detect new version of ParaView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.1...3.13 FATAL_ERROR)
 project(CGAL_Isotropic_remeshing_filter)
 #If the plugin is used internally (inside Paraview's source directory),
 #then we don't need to call find_package.
+
+find_package(MPI)
+
 if (NOT ParaView_BINARY_DIR)
   find_package(ParaView REQUIRED)
 endif()
@@ -11,7 +14,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
-if(PARAVIEW_USE_FILE)
+message("ParaView version: ${ParaView_VERSION}")
+
+if(ParaView_VERSION VERSION_LESS_EQUAL 5.6)
   # ParaView 5.6
   # ------------
   #If the plugin is used internally we don't need to include.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.1...3.13 FATAL_ERROR)
 project(CGAL_Isotropic_remeshing_filter)
 #If the plugin is used internally (inside Paraview's source directory),
 #then we don't need to call find_package.
-
-find_package(MPI)
-
 if (NOT ParaView_BINARY_DIR)
   find_package(ParaView REQUIRED)
 endif()

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ set(BUILD_SHARED_LIBS TRUE)
 #Paraview's macro to add the plugin. It takes care of all the vtk
 #and paraview parts of the process, like link and integration
 #in the UI
-if(ParaView_FOUND AND PARAVIEW_USE_FILE)
+if(ParaView_VERSION VERSION_LESS_EQUAL 5.6)
   ## ParaView 5.6
     add_subdirectory(IsotropicRemeshingFilters)
 else()

--- a/Plugin/IsotropicRemeshingFilters/CMakeLists.txt
+++ b/Plugin/IsotropicRemeshingFilters/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(CGAL REQUIRED)
 #Paraview's macro to add the plugin. It takes care of all the vtk
 #and paraview parts of the process, like link and integration
 #in the UI
-if(ParaView_FOUND AND PARAVIEW_USE_FILE)
+if(ParaView_VERSION VERSION_LESS_EQUAL 5.6)
   ## ParaView 5.6
   add_paraview_plugin(IsotropicRemeshingFilter "1.0"
     SERVER_MANAGER_XML IsotropicRemeshingFilter.xml


### PR DESCRIPTION
Hello,

this merge request replaces the usage of `PARAVIEW_USE_FILE` variable by a more reliable comparison with `ParaView_VERSION` variable, in order to build this plugin with recent ParaView (5.10 in my case).

Best,

François

