### PR TITLE
Fix xml to only accept PolyData in PV, plus virtual destructor

### DIFF
--- a/Plugin/IsotropicRemeshingFilters/IsotropicRemeshingFilter.xml
+++ b/Plugin/IsotropicRemeshingFilters/IsotropicRemeshingFilter.xml
@@ -1,10 +1,10 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
-    <SourceProxy name="IsotropicRemeshingFilter" class="vtkIsotropicRemeshingFilter" label="Isotropic Remeshing">
+    <SourceProxy name="IsotropicRemeshingFilter" class="vtkIsotropicRemeshingFilter" label="CGAL Isotropic Remeshing">
     <Documentation
       short_help="Remeshes datasets."
       long_help="Remeshes a dataset.">
-      This filter will remesh the given data set. It takes a PolyData 
+      This filter will remesh the given data set. It takes a PolyData
       as input, and returns a PolyData containing the remeshed input.
     </Documentation>
 <!-- Dialog to choose the input -->
@@ -17,7 +17,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkDataSet"/>
+          <DataType value="vtkPolyData"/>
         </DataTypeDomain>
         <Documentation>
           The input Meshes.

--- a/Plugin/IsotropicRemeshingFilters/vtkIsotropicRemeshingFilter.h
+++ b/Plugin/IsotropicRemeshingFilters/vtkIsotropicRemeshingFilter.h
@@ -36,7 +36,7 @@ public:
 
 protected:
   vtkIsotropicRemeshingFilter();
-  ~vtkIsotropicRemeshingFilter(){}
+  virtual ~vtkIsotropicRemeshingFilter(){}
 
   // Computes the bbox's diagonal length to set the default target edge length.
   int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *);


### PR DESCRIPTION
Hello,

Here is a small fix for the XML file that prevent to create this filter for dataset which are not PolyData (as the VTK module can only process the latter).

 I also suggest to add the prefix CGAL to the name of the filter. It may helps finding it in the quick filter windows. I can revert this change if you do not like it.

Best,
Charles